### PR TITLE
New functions GetLimit GetOffset GetRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bolt [![Coverage Status](https://coveralls.io/repos/boltdb/bolt/badge.svg?branch
 Extended BigBoltDB
 -------
 
-Extended BigboltDB is a fork of BigBoltDB that supports database
+Extended BigBoltDB is a fork of BigBoltDB that supports database
 compaction and thus can store big values (over 1MB)
 and support limit and range functions.
 
@@ -20,7 +20,8 @@ start := uint32(1048576)
 end := uint32(2097152)
 
 GetLimit([]byte(key), limit)
-GetRange([]byte(key), start, end)```
+GetRange([]byte(key), start, end)
+```
 
 Where limit, start, end - this is a count of bytes.
 
@@ -36,20 +37,20 @@ BigBoltDB
 
 Writing big values causes fragmententation of
 the backing file, requiring regular compaction to avoid
-infinite file growth. Bigboltdb provides a Compact() api
+infinite file growth. BigBoltDB provides a Compact() api
 call to do this, and a mechanism to establish regular,
 automatic compaction by setting the `db.CompactAfterCommitCount`
 field. 
 
-Other than this one change, bigboltdb is simple, friendly fork
-of boltdb.
+Other than this one change, BigBoltDB is simple, friendly fork
+of BoltDB.
 
 We intend stay completely compatable and to
 maintain 100% compatibility with upstream by merging any
 updates.
 
 This fork was required because the author of
-boltdb, sadly, does not wish to support compaction within boltdb.
+BoldDB, sadly, does not wish to support compaction within boltdb.
 Refer to https://github.com/boltdb/bolt/issues/674 and
 https://github.com/boltdb/bolt/pull/679 for the
 discussion.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Where limit, offset, start, end - this is a count of bytes.
 This functions need for partly reading values.
 
 For example, if you have some files with custom binary metadata inside values in boltdb,
-or if you need make support of Accept-Ranges for http server with backends in boltdb files,
-then you can save hdd/ssd reads by make read only small parts of value(metadata or range of bytes),
-not read full value.
+and if you need make support of HEAD/OPTIONS methods for read only metadata or Accept-Ranges for http server with backends in boltdb files, then you can dramatically save subsystem hdd/ssd by make read only small parts of value(metadata or range of bytes), and not read a full value of key from boltdb.
 
 BigBoltDB
 -------

--- a/README.md
+++ b/README.md
@@ -1,11 +1,38 @@
 Bolt [![Coverage Status](https://coveralls.io/repos/boltdb/bolt/badge.svg?branch=master)](https://coveralls.io/r/boltdb/bolt?branch=master) [![GoDoc](https://godoc.org/github.com/boltdb/bolt?status.svg)](https://godoc.org/github.com/boltdb/bolt) ![Version](https://img.shields.io/badge/version-1.2.1-green.svg)
 ====
 
-bigboltdb
+Extended BigBoltDB
 -------
 
-Bigboltdb is a fork of boltdb that supports database
-compaction and thus can store big values (over 1MB).
+Extended BigboltDB is a fork of BigBoltDB that supports database
+compaction and thus can store big values (over 1MB)
+and support limit and range functions.
+
+Two new functions in Extended BigBoltDB:
+
+GetLimit([]byte(key), uint32)
+GetRange([]byte(key), uint32, uint32)
+
+Example:
+
+```limit := uint32(1048576)
+start := uint32(1048576)
+end := uint32(2097152)
+
+GetLimit([]byte(key), limit)
+GetRange([]byte(key), start, end)```
+
+Where limit, start, end - this is a count of bytes.
+
+This functions need for partly reading values.
+
+For example, if you have some files with custom binary metadata inside values in boltdb,
+or if you need make support of Accept-Ranges for http server with backends in boltdb files,
+then you can save hdd/ssd reads by make read only small parts of value(metadata or range of bytes),
+not read full value.
+
+BigBoltDB
+-------
 
 Writing big values causes fragmententation of
 the backing file, requiring regular compaction to avoid
@@ -29,7 +56,7 @@ discussion.
 
 Now back to your regularly scheduled README... See also https://github.com/boltdb/bolt.
 
-boltdb
+BoltDB
 ------
 
 Bolt is a pure Go key/value store inspired by [Howard Chu's][hyc_symas]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Extended BigBoltDB
 
 Extended BigBoltDB is a fork of BigBoltDB that supports database
 compaction and thus can store big values (over 1MB)
-and support limit and range functions.
+and support limit, offset and range functions.
 
 Three new functions in Extended BigBoltDB:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Extended BigBoltDB is a fork of BigBoltDB that supports database
 compaction and thus can store big values (over 1MB)
 and support limit and range functions.
 
-Two new functions in Extended BigBoltDB:
+Three new functions in Extended BigBoltDB:
 
 GetLimit([]byte(key), uint32)
+
+GetOffset([]byte(key), uint32)
 
 GetRange([]byte(key), uint32, uint32)
 
@@ -20,14 +22,16 @@ Example:
 key := "mykey"
 
 limit := uint32(1048576)
+offset: = uint32(131072)
 start := uint32(1048576)
 end := uint32(2097152)
 
 GetLimit([]byte(key), limit)
+GetOffset([]byte(key), offset)
 GetRange([]byte(key), start, end)
 ```
 
-Where limit, start, end - this is a count of bytes.
+Where limit, offset, start, end - this is a count of bytes.
 
 This functions need for partly reading values.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ GetRange([]byte(key), uint32, uint32)
 
 Example:
 
-```limit := uint32(1048576)
+```
+key := "mykey"
+
+limit := uint32(1048576)
 start := uint32(1048576)
 end := uint32(2097152)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and support limit and range functions.
 Two new functions in Extended BigBoltDB:
 
 GetLimit([]byte(key), uint32)
+
 GetRange([]byte(key), uint32, uint32)
 
 Example:

--- a/bucket.go
+++ b/bucket.go
@@ -296,6 +296,24 @@ func (b *Bucket) GetLimit(key []byte, lbytes uint32) []byte {
 	return v
 }
 
+// GetOffset retrieves the value for a key in the bucket with skipped bytes count.
+// Returns a nil value if the key does not exist or if the key is a nested bucket.
+// The returned value is only valid for the life of the transaction.
+func (b *Bucket) GetOffset(key []byte, obytes uint32) []byte {
+	k, v, flags := b.Cursor().seekoffset(key, obytes)
+
+	// Return nil if this is a bucket.
+	if (flags & bucketLeafFlag) != 0 {
+		return nil
+	}
+
+	// If our target node isn't the same key as what's passed in then return nil.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+	return v
+}
+
 // GetRange retrieves the value for a key in the bucket limited by bytes range.
 // Returns a nil value if the key does not exist or if the key is a nested bucket.
 // The returned value is only valid for the life of the transaction.

--- a/bucket.go
+++ b/bucket.go
@@ -278,6 +278,42 @@ func (b *Bucket) Get(key []byte) []byte {
 	return v
 }
 
+// GetLimit retrieves the value for a key in the bucket limited by bytes count.
+// Returns a nil value if the key does not exist or if the key is a nested bucket.
+// The returned value is only valid for the life of the transaction.
+func (b *Bucket) GetLimit(key []byte, lbytes uint32) []byte {
+	k, v, flags := b.Cursor().seeklimit(key, lbytes)
+
+	// Return nil if this is a bucket.
+	if (flags & bucketLeafFlag) != 0 {
+		return nil
+	}
+
+	// If our target node isn't the same key as what's passed in then return nil.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+	return v
+}
+
+// GetRange retrieves the value for a key in the bucket limited by bytes range.
+// Returns a nil value if the key does not exist or if the key is a nested bucket.
+// The returned value is only valid for the life of the transaction.
+func (b *Bucket) GetRange(key []byte, sbytes uint32, lbytes uint32) []byte {
+	k, v, flags := b.Cursor().seekrange(key, sbytes, lbytes)
+
+	// Return nil if this is a bucket.
+	if (flags & bucketLeafFlag) != 0 {
+		return nil
+	}
+
+	// If our target node isn't the same key as what's passed in then return nil.
+	if !bytes.Equal(key, k) {
+		return nil
+	}
+	return v
+}
+
 // Put sets the value for a key in the bucket.
 // If the key exist then its previous value will be overwritten.
 // Supplied value must remain valid for the life of the transaction.

--- a/cursor.go
+++ b/cursor.go
@@ -168,6 +168,44 @@ func (c *Cursor) seek(seek []byte) (key []byte, value []byte, flags uint32) {
 	return c.keyValue()
 }
 
+// seeklimit moves the cursor to a given key and returns it.
+// If the key does not exist then the next key is used.
+func (c *Cursor) seeklimit(seek []byte, lbytes uint32) (key []byte, value []byte, flags uint32) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+
+	// Start from root page/node and traverse to correct page.
+	c.stack = c.stack[:0]
+	c.search(seek, c.bucket.root)
+	ref := &c.stack[len(c.stack)-1]
+
+	// If the cursor is pointing to the end of page/node then return nil.
+	if ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// If this is a bucket then return a nil value.
+	return c.keyValueLimit(lbytes)
+}
+
+// seekrange moves the cursor to a given key and returns it.
+// If the key does not exist then the next key is used.
+func (c *Cursor) seekrange(seek []byte, sbytes uint32, lbytes uint32) (key []byte, value []byte, flags uint32) {
+	_assert(c.bucket.tx.db != nil, "tx closed")
+
+	// Start from root page/node and traverse to correct page.
+	c.stack = c.stack[:0]
+	c.search(seek, c.bucket.root)
+	ref := &c.stack[len(c.stack)-1]
+
+	// If the cursor is pointing to the end of page/node then return nil.
+	if ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// If this is a bucket then return a nil value.
+	return c.keyValueRange(sbytes, lbytes)
+}
+
 // first moves the cursor to the first leaf element under the last page in the stack.
 func (c *Cursor) first() {
 	for {
@@ -351,6 +389,42 @@ func (c *Cursor) keyValue() ([]byte, []byte, uint32) {
 
 	// Or retrieve value from page.
 	elem := ref.page.leafPageElement(uint16(ref.index))
+	return elem.key(), elem.value(), elem.flags
+}
+
+// keyValueLimit returns the key and value of the current leaf element limited by bytes count.
+func (c *Cursor) keyValueLimit(lbytes uint32) ([]byte, []byte, uint32) {
+	ref := &c.stack[len(c.stack)-1]
+	if ref.count() == 0 || ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// Retrieve value from node.
+	if ref.node != nil {
+		inode := &ref.node.inodes[ref.index]
+		return inode.key, inode.value, inode.flags
+	}
+
+	// Or retrieve value from page.
+	elem := ref.page.leafPageElementLimit(uint16(ref.index), lbytes)
+	return elem.key(), elem.value(), elem.flags
+}
+
+// keyValueRange returns the key and value of the current leaf element limited by bytes range.
+func (c *Cursor) keyValueRange(sbytes uint32, lbytes uint32) ([]byte, []byte, uint32) {
+	ref := &c.stack[len(c.stack)-1]
+	if ref.count() == 0 || ref.index >= ref.count() {
+		return nil, nil, 0
+	}
+
+	// Retrieve value from node.
+	if ref.node != nil {
+		inode := &ref.node.inodes[ref.index]
+		return inode.key, inode.value, inode.flags
+	}
+
+	// Or retrieve value from page.
+	elem := ref.page.leafPageElementRange(uint16(ref.index), sbytes, lbytes)
 	return elem.key(), elem.value(), elem.flags
 }
 

--- a/page.go
+++ b/page.go
@@ -216,7 +216,7 @@ func (n *leafPageElementOffset) value() []byte {
 		ombytes = 0
 	}
 
-	embytes := n.vsize - ombyte
+	embytes := n.vsize - ombytes
 
 	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos+n.ksize+ombytes]))[:embytes:embytes]
 }

--- a/page.go
+++ b/page.go
@@ -216,7 +216,9 @@ func (n *leafPageElementOffset) value() []byte {
 		ombytes = 0
 	}
 
-	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos+n.ksize+ombytes]))[:n.vsize:n.vsize]
+	embytes := n.vsize - ombyte
+
+	return (*[maxAllocSize]byte)(unsafe.Pointer(&buf[n.pos+n.ksize+ombytes]))[:embytes:embytes]
 }
 
 // value returns a byte slice of the node value limited by bytes range.


### PR DESCRIPTION
Hello. But i say before - I am a bad Go programmer, can you check this code?

Three new functions fot BigBoltDB:

GetLimit([]byte(key), uint32)

GetOffset([]byte(key), uint32)

GetRange([]byte(key), uint32, uint32)

Example:

key := "mykey"

limit := uint32(1048576)
offset: = uint32(131072)
start := uint32(1048576)
end := uint32(2097152)

GetLimit([]byte(key), limit)
GetOffset([]byte(key), offset)
GetRange([]byte(key), start, end)
Where limit, offset, start, end - this is a count of bytes.

This functions need for partly reading values.

For example, if you have some files with custom binary metadata inside values in boltdb, and if you need make support of HEAD/OPTIONS methods for read only metadata or Accept-Ranges for http server with backends in boltdb files, then you can dramatically save subsystem hdd/ssd by make read only small parts of value(metadata or range of bytes), and not read a full value of key from boltdb.